### PR TITLE
Better error reporting on invalid query

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ mod filters {
 pub fn filter_stream<'de, R>(query: String, reader: R, func: fn(Value)) where R: Read<'de> {
     // Parse query string to AST
     match parse_query(&query) {
-        Err(error) => panic!(error),
+        Err(error) => panic!("Bad query: {}", error),
         Ok(ast) => {
             // Convert AST to selection tree
             let selection = filters::get_selection(ast);


### PR DESCRIPTION
It still panics, but previous error was:
```
thread 'main' panicked at 'Box<Any>', src/lib.rs:190:23
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```
Now it looks like:
```
thread 'main' panicked at 'Bad query: query parse error: Parse error at 1:2
Unexpected `}[Punctuator]`
Expected `Name` or `...`
', src/lib.rs:190:23
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```