### PR TITLE
Add `(entries: true)` argument support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ mod filters {
 pub fn filter_stream<'de, R>(query: String, reader: R, func: fn(Value)) where R: Read<'de> {
     // Parse query string to AST
     match parse_query(&query) {
-        Err(error) => panic!(error),
+        Err(error) => panic!("Bad query: {}", error),
         Ok(ast) => {
             // Convert AST to selection tree
             let selection = filters::get_selection(ast);


### PR DESCRIPTION
Added a quick experiment allowing to iterate over keys of a javascript object treating it like a dict.
    
I.e. filter like ``{ field(entries: true) }`` is treated like the data in the field not an object of ``{"key1": "value1"}`` but an array of ``[{"key": "key1", "value": "value1"}]

In other words, this allows working with javascript objects with keys unknown in advance.

(this builds upon better_error branch in #1)